### PR TITLE
Republish mime crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate mime;
 extern crate phf;
 extern crate unicase;
 
-use mime::Mime;
+pub use mime::Mime;
 use unicase::UniCase;
 
 use std::ffi::OsStr;


### PR DESCRIPTION
User of this crate forced to add `mime` crate dependency even if it needs to interact with this crate only (because it return unwrapped `Mime` results).

This PR makes possible to reuse `mime` crate to prevent possible conflicts:

``` rust
error[E0308]: mismatched types
  --> src\provider.rs:81:12
   |
81 |                                    mime: guess_mime_type(path),
   |                                          ^^^^^^^^^^^^^^^^^^^^^ expected struct `mime::Mime`, found a different struct `mime::Mime`
   |
   = note: expected type `mime::Mime` (struct `mime::Mime`)
   = note:    found type `mime::Mime` (struct `mime::Mime`)
note: Perhaps two different versions of crate `mime` are being used?
```
