### PR TITLE
Add `.hh` as `text/plain`

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -163,6 +163,7 @@ pub static MIME_TYPES: &'static [(&'static str, &'static str)] = &[
     ("h", "text/plain"),
     ("hdf", "application/x-hdf"),
     ("hdml", "text/x-hdml"),
+    ("hh", "text/plain"),
     ("hhc", "application/x-oleobject"),
     ("hhk", "application/octet-stream"),
     ("hhp", "application/octet-stream"),


### PR DESCRIPTION
`.hh` is sometimes used as an extension for C++ header files. Just like `.cc` or `.cpp`, it is `text/plain`.