### PR TITLE
Add `.py` as `text/plain`

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -392,6 +392,7 @@ pub static MIME_TYPES: &'static [(&'static str, &'static str)] = &[
     ("pst", "application/vnd.ms-outlook"),
     ("pub", "application/x-mspublisher"),
     ("pwz", "application/vnd.ms-powerpoint"),
+    ("py", "text/plain"),
     ("qht", "text/x-html-insertion"),
     ("qhtm", "text/x-html-insertion"),
     ("qt", "video/quicktime"),


### PR DESCRIPTION
Python files (`*.py`) are plain text files.