### PR TITLE
Update phf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ bench = []
 
 [dependencies]
 mime = "0.3"
-phf = { version = "0.7", features = ["unicase"] }
+phf = { version = "0.7.22", features = ["unicase"] }
 unicase = "1.1"
 
 [build-dependencies]
-phf_codegen = "0.7"
+phf_codegen = "0.7.22"
 unicase = "1.1"


### PR DESCRIPTION
This is necessary to avoid build failures with -Zminimal-versions. Not the newest version of phf, but it doesn't matter as long it's at least 0.7.22.