### PR TITLE
re-export mime lib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ extern crate mime;
 extern crate phf;
 extern crate unicase;
 
-pub use mime::Mime;
+pub use mime::*;
 use unicase::UniCase;
 
 use std::ffi::OsStr;
@@ -214,7 +214,6 @@ fn map_lookup<'map, V>(map: &'map phf::Map<UniCase<&'static str>, V>, key: &str)
 #[cfg(test)]
 mod tests {
     use mime::Mime;
-    use std::ascii::AsciiExt;
     use std::path::Path;
     use super::{get_mime_type, guess_mime_type, MIME_TYPES};
     use super::{get_mime_type_opt, guess_mime_type_opt};


### PR DESCRIPTION
as mime_guess does not use the latest mime crate, it can creates
conflict when a project explicitly import both crates as the `Mime`
type from both crates differs (as they are coming from different
version of the mime crate).

By pub using `mime::*` then the library consumer can access helper
functions of the correct `mime` crate such as `mime::TEXT_HTML`.

Also, AsciiExt is unused and produces a warning at build time.