### PR TITLE
Return correct mime type for md

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -649,7 +649,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("mc1", &["application/vnd.medcalcdata"]),
     ("mcd", &["application/vnd.mcd"]),
     ("mcurl", &["text/vnd.curl.mcurl"]),
-    ("md", &["text/x-markdown"]),
+    ("md", &["text/markdown"]),
     ("mda", &["application/msaccess"]),
     ("mdb", &["application/x-msaccess"]),
     ("mde", &["application/msaccess"]),


### PR DESCRIPTION
Per RFC https://tools.ietf.org/html/rfc7763
The official file types for markdown are .md, and .markdown
So .md should be text/markdown