### PR TITLE
Change text/x-markdown to text/markdown

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -649,7 +649,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("mc1", &["application/vnd.medcalcdata"]),
     ("mcd", &["application/vnd.mcd"]),
     ("mcurl", &["text/vnd.curl.mcurl"]),
-    ("md", &["text/x-markdown"]),
+    ("md", &["text/markdown"]),
     ("mda", &["application/msaccess"]),
     ("mdb", &["application/x-msaccess"]),
     ("mde", &["application/msaccess"]),


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc7763#section-2, which lists `text/markdown` as having the `.md` and `.markdown` extensions. This also makes `.md` consistent with `.markdown`.

cc https://github.com/rust-lang/docs.rs/pull/586