### PR TITLE
Add build dependency on phf with the unicase feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,10 @@ phf = { version = "0.7", features = ["unicase"] }
 unicase = "1.1"
 
 [build-dependencies]
+# phf is here in order to work around the fact that phf_codegen does not
+# expose the unicase feature, but depends on phf_shared being compiled with
+# unicase enabled. This enables mime_guess to compile even with the new -Z
+# features resolver in cargo.
+phf = { version = "0.7", features = ["unicase"] }
 phf_codegen = "0.7"
 unicase = "1.1"


### PR DESCRIPTION
We don't directly use phf in the build script, but we do need phf_shared to be
compiled with the unicase feature to work. The only way to do that is to
build-depend on phf with the unicase feature, so that phf_shared with unicase
is enabled.

This fixes a dependency declaration problem which was found by the new `-Z features` dependency resolver in cargo.

This and a publish will fix #56.