### PR TITLE
fix panic in get_mime_extensions_str

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,10 +401,7 @@ pub fn get_mime_extensions_str(mut mime_str: &str) -> Option<&'static [&'static 
     }
 
     let (top, sub) = {
-        let split_idx = match mime_str.find('/') {
-            Some(idx) => idx,
-            None => return None,
-        };
+        let split_idx = mime_str.find('/')?;
         (&mime_str[..split_idx], &mime_str[split_idx + 1..])
     };
 
@@ -442,7 +439,6 @@ mod tests {
     use std::fmt::Debug;
     use std::path::Path;
 
-
     #[test]
     fn check_type_bounds() {
         fn assert_type_bounds<T: Clone + Debug + Send + Sync + 'static>() {}
@@ -474,7 +470,9 @@ mod tests {
             "image/gif".to_string()
         );
         assert_eq!(
-            from_path("/path/to/file.gif").first_or_octet_stream().to_string(),
+            from_path("/path/to/file.gif")
+                .first_or_octet_stream()
+                .to_string(),
             "image/gif".to_string()
         );
     }
@@ -501,7 +499,9 @@ mod tests {
     #[test]
     fn test_are_mime_types_parseable() {
         for (_, mimes) in MIME_TYPES {
-            mimes.iter().for_each(|s| { expect_mime(s); });
+            mimes.iter().for_each(|s| {
+                expect_mime(s);
+            });
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,10 @@ pub fn get_mime_extensions_str(mut mime_str: &str) -> Option<&'static [&'static 
     }
 
     let (top, sub) = {
-        let split_idx = mime_str.find('/').unwrap();
+        let split_idx = match mime_str.find('/') {
+            Some(idx) => idx,
+            None => return None,
+        };
         (&mime_str[..split_idx], &mime_str[split_idx + 1..])
     };
 
@@ -432,7 +435,7 @@ pub fn octet_stream() -> Mime {
 mod tests {
     include!("mime_types.rs");
 
-    use super::{from_ext, from_path, expect_mime};
+    use super::{expect_mime, from_ext, from_path, get_mime_extensions_str};
     #[allow(deprecated, unused_imports)]
     use std::ascii::AsciiExt;
 
@@ -522,5 +525,10 @@ mod tests {
                 n_ext
             );
         }
+    }
+
+    #[test]
+    fn test_get_mime_extensions_str_no_panic_if_bad_mime() {
+        assert_eq!(get_mime_extensions_str(""), None);
     }
 }


### PR DESCRIPTION
Hello,

`get_mime_extensions_str` should not panic if the mime type does not contains `'/'` and return `None` instead.

Thank you very much in advance for your merge.
Cheers !