### PR TITLE
Add AVIF media type registrations

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -102,6 +102,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("atx", &["application/vnd.antix.game-component"]),
     ("au", &["audio/basic"]),
     ("avi", &["video/x-msvideo"]),
+    ("avif", &["image/avif"]),
     ("aw", &["application/applixware"]),
     ("axa", &["audio/annodex"]),
     ("axs", &["application/olescript"]),


### PR DESCRIPTION
The new media type is submitted to IANA but has not been formally
published by IANA yet. Both Firefox and Chromium are already using
the mime type for AVIF images.

Citation: https://aomediacodec.github.io/av1-avif/#mime-registration