### PR TITLE
Add new mimetype for '.feature' files used in cucumber (Gherkin)

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -354,6 +354,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("fcs", &["application/vnd.isac.fcs"]),
     ("fdf", &["application/vnd.fdf"]),
     ("fe_launch", &["application/vnd.denovo.fcselayout-link"]),
+    ("feature", &["text/x-gherkin"]),
     ("fg5", &["application/vnd.fujitsu.oasysgp"]),
     ("fgd", &["application/x-director"]),
     ("fh", &["image/x-freehand"]),


### PR DESCRIPTION
Cucumber is a Ruby software used for behavior-driven development (BDD).
The tests are written in the "Gherkin" language in text files with the '.feature' extension[^1].

A pure Rust implementation of [cucumber is available](https://github.com/bbqsrc/cucumber-rust).

The language description has been archived[^2].

The package `xdg-shared-mime-info` accepted[^3] the extension in its
database[^4] as 'text/x-gherkin'.

[^1] https://en.wikipedia.org/wiki/Cucumber_(software)#Gherkin_language
[^2] https://web.archive.org/web/20151025214933/https://cucumber.io/docs/reference
[^3] https://bugs.freedesktop.org/show_bug.cgi?id=95455
[^4] https://github.com/freedesktop/xdg-shared-mime-info/blob/dedbf256bf7e7a4ee106b645dc2bc0fc3b21ea8c/data/freedesktop.org.xml.in#L6009-L6013