### PR TITLE
update entry for `jfif`

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -542,7 +542,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("java", &["application/octet-stream"]),
     ("jck", &["application/liquidmotion"]),
     ("jcz", &["application/liquidmotion"]),
-    ("jfif", &["image/pjpeg"]),
+    ("jfif", &["image/jpeg"]),
     ("jisp", &["application/vnd.jisp"]),
     ("jlt", &["application/vnd.hp-jlyt"]),
     ("jng", &["image/x-jng"]),


### PR DESCRIPTION
It would seem that `image/pjpeg` is a weird thing invented by IE. I have been unable to find any references to it outside of that context (for example, in any RFC). Additionally, JFIF (jpeg file interchange format) does not imply progressive encoding, so I don't think this is correct anyway.