### PR TITLE
Use platform specific path separators

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,12 @@ const PHF_PATH: &str = "::impl_::phf";
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("mime_types_generated.rs");
-    let mut outfile = BufWriter::new(File::create(dest_path).unwrap());
+    let mut outfile = BufWriter::new(File::create(&dest_path).unwrap());
+
+    println!(
+        "cargo:rustc-env=MIME_TYPES_GENERATED_PATH={}",
+        dest_path.display()
+    );
 
     #[cfg(feature = "phf")]
     build_forward_map(&mut outfile);

--- a/src/impl_bin_search.rs
+++ b/src/impl_bin_search.rs
@@ -1,7 +1,7 @@
 use unicase::UniCase;
 
 include!("mime_types.rs");
-include!(concat!(env!("OUT_DIR"), "/mime_types_generated.rs"));
+include!(env!("MIME_TYPES_GENERATED_PATH"));
 
 #[cfg(feature = "rev-mappings")]
 #[derive(Copy, Clone)]

--- a/src/impl_phf.rs
+++ b/src/impl_phf.rs
@@ -2,7 +2,7 @@ extern crate phf;
 
 use unicase::UniCase;
 
-include!(concat!(env!("OUT_DIR"), "/mime_types_generated.rs"));
+include!(env!("MIME_TYPES_GENERATED_PATH"));
 
 #[cfg(feature = "rev-mappings")]
 struct TopLevelExts {


### PR DESCRIPTION
Problem:
- When `include!(..)`ing the `mime_types_generated` file, it was assumed that the separator was `/`. However, this will occasionally break on windows causing a compile error.

Solution
- From the build script, embed the file path into a compile-time `env!` which uses the correct path separator.

Fixes #78