### PR TITLE
refactor: use correct MIME type for ics

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -490,7 +490,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("ice", &["x-conference/x-cooltalk"]),
     ("icm", &["application/vnd.iccprofile"]),
     ("ico", &["image/x-icon"]),
-    ("ics", &["application/octet-stream"]),
+    ("ics", &["text/calendar"]),
     ("idl", &["text/plain"]),
     ("ief", &["image/ief"]),
     ("ifb", &["text/calendar"]),


### PR DESCRIPTION
Instead of using the default application/octet-stream mime type for ics format use the appropriate text/calendar mime type according to RFC 2445 (https://www.ietf.org/rfc/rfc2445.txt).