### PR TITLE
Add support for application `application/x-gzip`

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -437,7 +437,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("gv", &["text/vnd.graphviz"]),
     ("gxf", &["application/gxf"]),
     ("gxt", &["application/vnd.geonext"]),
-    ("gz", &["application/gzip"]),
+    ("gz", &["application/gzip", "application/x-gzip"]),
     ("h", &["text/plain"]),
     ("h261", &["video/h261"]),
     ("h263", &["video/h263"]),


### PR DESCRIPTION
Add support for application `application/x-gzip`, equivalent of `application/gzip` since some servers still use this content-type header, example below

reference:
https://stackoverflow.com/questions/21870351/difference-between-x-gzip-and-gzip-for-content-encoding https://mimetype.io/application/x-gzip

![image](https://github.com/abonander/mime_guess/assets/108927690/a0c60baa-6bcb-4e04-a846-b2bb9fdeb8eb)
