### PR TITLE
Add new mime type entry for `.parquet`

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -862,6 +862,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("p7s", &["application/pkcs7-signature"]),
     ("p8", &["application/pkcs8"]),
     ("pac", &["application/x-ns-proxy-autoconfig"]),
+    ("parquet", &["application/vnd.apache.parquet", "application/x-parquet"]),
     ("pas", &["text/x-pascal"]),
     ("paw", &["application/vnd.pawaafile"]),
     ("pbd", &["application/vnd.powerbuilder6"]),


### PR DESCRIPTION
The `application/vnd.apache.parquet` mime type was recently registered with IANA: https://www.iana.org/assignments/media-types/application/vnd.apache.parquet

This also includes the deprecated `application/x-parquet` mime type in the list as it was mentioned on the media type assignment page above.