### PR TITLE
Change rpm mimetype to application/x-rpm

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -1052,7 +1052,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("roa", &["application/rpki-roa"]),
     ("roff", &["application/x-troff"]),
     ("rp9", &["application/vnd.cloanto.rp9"]),
-    ("rpm", &["audio/x-pn-realaudio-plugin"]),
+    ("rpm", &["application/x-rpm"]),
     ("rpss", &["application/vnd.nokia.radio-presets"]),
     ("rpst", &["application/vnd.nokia.radio-preset"]),
     ("rq", &["application/sparql-query"]),


### PR DESCRIPTION
application/x-rpm seems to be the more common type at this point.

I wasn't sure if I should keep the previous type in the list as well.