### PR TITLE
Update mime type of `.woff` files

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -1408,7 +1408,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("wmv", &["video/x-ms-wmv"]),
     ("wmx", &["video/x-ms-wmx"]),
     ("wmz", &["application/x-ms-wmz"]),
-    ("woff", &["application/font-woff"]),
+    ("woff", &["font/woff", "application/font-woff"]),
     ("woff2", &["font/woff2"]),
     ("wpd", &["application/vnd.wordperfect"]),
     ("wpl", &["application/vnd.ms-wpl"]),


### PR DESCRIPTION
If you seach for "woff" within  https://www.iana.org/assignments/media-types/media-types.xhtml you'll find that `application/font-woff` has been deprecated and replaced with `font/woff`.