### PR TITLE
Support running build script and compilation on different machines

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufWriter;
-use std::path::Path;
+use std::path::{self, Path};
 
 use std::collections::BTreeMap;
 
@@ -22,12 +22,14 @@ const PHF_PATH: &str = "::impl_::phf";
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
-    let dest_path = Path::new(&out_dir).join("mime_types_generated.rs");
+    let mime_types_generated_filename = "mime_types_generated.rs";
+    let dest_path = Path::new(&out_dir).join(mime_types_generated_filename);
     let mut outfile = BufWriter::new(File::create(&dest_path).unwrap());
 
     println!(
-        "cargo:rustc-env=MIME_TYPES_GENERATED_PATH={}",
-        dest_path.display()
+        "cargo:rustc-env=MIME_TYPES_GENERATED_PATH={separator}{filename}",
+        separator = path::MAIN_SEPARATOR,
+        filename = mime_types_generated_filename,
     );
 
     #[cfg(feature = "phf")]

--- a/src/impl_bin_search.rs
+++ b/src/impl_bin_search.rs
@@ -1,7 +1,7 @@
 use unicase::UniCase;
 
 include!("mime_types.rs");
-include!(env!("MIME_TYPES_GENERATED_PATH"));
+include!(concat!(env!("OUT_DIR"), env!("MIME_TYPES_GENERATED_PATH")));
 
 #[cfg(feature = "rev-mappings")]
 #[derive(Copy, Clone)]

--- a/src/impl_phf.rs
+++ b/src/impl_phf.rs
@@ -2,7 +2,7 @@ extern crate phf;
 
 use unicase::UniCase;
 
-include!(env!("MIME_TYPES_GENERATED_PATH"));
+include!(concat!(env!("OUT_DIR"), env!("MIME_TYPES_GENERATED_PATH")));
 
 #[cfg(feature = "rev-mappings")]
 struct TopLevelExts {


### PR DESCRIPTION
Build systems that perform remote execution usually want to be able to run build scripts and library compilation as different actions, potentially on different machines. This is because the build script compilation and execution can take place as soon as the package's `build-dependencies` are ready, while library compilation can take place as soon as `dependencies` are ready, which may be substantially later. If `dependencies` are ready later, the machine that dealt with the build script may not be immediately available at that time, and library compilation will run on any other available remote machine.

The `mime_guess` change from https://github.com/abonander/mime_guess/pull/79 disrupted this by exposing an absolute path from the machine that did build script execution and then trying to resolve that path later on the machine that does the library compilation. The two actions likely occur in different working directories. For example it's typical for remote executors to use directories that include a digest of the action's inputs, particularly if actions are distributed using a content-addressable storage where they are already uniquely identified by such a digest.

Cargo's API for build scripts is that anything written into `env::var_os("OUT_DIR")` by the build script execution will be available inside `env!("OUT_DIR")` during library compilation. It is not part of the API that those are necessarily the same absolute path to OUT_DIR both times.