### PR TITLE
Add an entry for .cda

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -160,6 +160,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("cct", &["application/x-director"]),
     ("ccxml", &["application/ccxml+xml"]),
     ("cd", &["text/plain"]),
+    ("cda", &["application/x-cdf"]),
     ("cdbcmsg", &["application/vnd.contact.cmsg"]),
     ("cdda", &["audio/aiff"]),
     ("cdf", &["application/x-cdf"]),


### PR DESCRIPTION
".cda" corresponding to "application/x-cdf" is listed in [MDN's "Common media types" page]. By my count, it is the only entry on that page not yet covered in the mime_guess crate.

It is not in IANA. It is in [Debian's media-types].

[MDN's "Common media types" page]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types
[Debian's media-types]: https://salsa.debian.org/debian/media-types/-/blob/b99439b8ab8e5807240b4919d559dab568ad3e4c/mime.types#L1657