### PR TITLE
feat: add support for QOI files

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -1003,6 +1003,7 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("qfx", &["application/vnd.intu.qfx"]),
     ("qht", &["text/x-html-insertion"]),
     ("qhtm", &["text/x-html-insertion"]),
+    ("qoi", &["image/qoi", "image/x-qoi"]),
     ("qps", &["application/vnd.publishare-delta-tree"]),
     ("qt", &["video/quicktime"]),
     ("qti", &["image/x-quicktime"]),


### PR DESCRIPTION
Defaults to `image/qoi` as specified in xdg [here](https://gitlab.freedesktop.org/xdg/shared-mime-info/-/blob/master/data/freedesktop.org.xml.in) and in the relevant GitHub issue for QOI [here](https://github.com/phoboslab/qoi/issues/167), but also lists `image/x-qoi` as apparently some programs used to use that (see discussion in the linked issue).