### PR TITLE
Map .zst to application/zstd

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -1534,4 +1534,5 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("zir", &["application/vnd.zul"]),
     ("zirz", &["application/vnd.zul"]),
     ("zmm", &["application/vnd.handheld-entertainment+xml"]),
+    ("zst", &["application/zstd"]),
 ];


### PR DESCRIPTION
IANA: https://www.iana.org/assignments/media-types/application/zstd
```
Type name:  application
Subtype name:  zstd
File extension(s): zst
```

Debian: https://salsa.debian.org/debian/media-types/-/blob/b99439b8ab8e5807240b4919d559dab568ad3e4c/mime.types#L1657
```
application/zstd				zst
```